### PR TITLE
Add the capability to pass an argument to osmosdr

### DIFF
--- a/apps/modes_rx
+++ b/apps/modes_rx
@@ -81,7 +81,7 @@ class adsb_rx_block (gr.top_block):
       
     elif options.rtlsdr: #RTLSDR dongle
         import osmosdr
-        self.u = osmosdr.source_c()
+        self.u = osmosdr.source_c(options.rtlsdr_arg)
         self.u.set_sample_rate(2.4e6) #fixed for RTL dongles
         if not self.u.set_center_freq(options.freq):
             print "Failed to set initial frequency"
@@ -171,6 +171,8 @@ if __name__ == '__main__':
                       help="FlightGear server to send aircraft data, in format host:port")
   parser.add_option("-d","--rtlsdr", action="store_true", default=False,
                       help="Use RTLSDR dongle instead of UHD source")
+  parser.add_option("-D","--rtlsdr_arg", type="string", default="",
+                    help="RTLSDR additional argument (for instance: 'rtl_tcp=127.0.0.1:1234')")
                       
   (options, args) = parser.parse_args()
 


### PR DESCRIPTION
A new command line option for modes_rx (-D) to be able to pass an
argument to osmosdr module. It is useful for instance when using
rtl_tcp, you can connect to the remote dongle by doing:
modes_rx -d -D rtl_tcp=127.0.0.1:1234

Signed-off-by: Antoine Sirinelli antoine@monte-stello.com
