### PR TITLE
Fixed erroneous include dir variable

### DIFF
--- a/cmake/Modules/FindGnuradioCore.cmake
+++ b/cmake/Modules/FindGnuradioCore.cmake
@@ -5,7 +5,7 @@ FIND_PATH(
     GNURADIO_CORE_INCLUDE_DIRS
     NAMES gr_random.h
     HINTS $ENV{GNURADIO_CORE_DIR}/include/gnuradio
-        ${PC_GNURADIO_CORE_INCLUDE_DIR}
+        ${PC_GNURADIO_CORE_INCLUDEDIR}
     PATHS /usr/local/include/gnuradio
           /usr/include/gnuradio
 )


### PR DESCRIPTION
FindGnuradioCore was only working if GNU Radio was installed in
typical paths, since the pkg-config variable was wrong.

This was fixed in GNU Radio HOWTO a while back.
