### PR TITLE
Refactor flowgraph into hierarchical block

### DIFF
--- a/apps/modes_gui
+++ b/apps/modes_gui
@@ -409,23 +409,15 @@ class adsb_rx_block (gr.top_block):
         else:
             raise NotImplementedError
 
-        self.demod = gr.complex_to_mag()
-        self.avg = gr.moving_average_ff(100, 1.0/100, 400)
-
-        self.preamble = air_modes.modes_preamble(int(rate), float(options["threshold"]))
-        self.slicer = air_modes.modes_slicer(int(rate), queue)
+        self.rx_path = air_modes.rx_path(rate, options["threshold"], queue)
 
         if use_resampler:
             self.lpfiltcoeffs = gr.firdes.low_pass(1, 5*3.2e6, 1.6e6, 300e3)
             self.resample = blks2.rational_resampler_ccf(interpolation=5, decimation=4, taps=self.lpfiltcoeffs)
-            self.connect(self.u, self.resample, self.demod)
+            self.connect(self.u, self.resample, self.rx_path)
         else:
-            self.connect(self.u, self.demod)
+            self.connect(self.u, self.rx_path)
 
-        self.connect(self.demod, self.avg)
-        self.connect(self.demod, (self.preamble, 0))
-        self.connect(self.avg, (self.preamble, 1))
-        self.connect(self.preamble, self.slicer)
 
 if __name__ == '__main__':
     app = QtGui.QApplication(sys.argv)

--- a/apps/modes_rx
+++ b/apps/modes_rx
@@ -110,24 +110,14 @@ class adsb_rx_block (gr.top_block):
     if options.output_all :
       pass_all = 1
 
-    self.demod = gr.complex_to_mag()
-    self.avg = gr.moving_average_ff(100, 1.0/100, 400)
-    
-    self.preamble = air_modes.modes_preamble(rate, options.threshold)
-    #self.framer = air_modes.modes_framer(rate)
-    self.slicer = air_modes.modes_slicer(rate, queue)
+    self.rx_path = air_modes.rx_path(rate, options.threshold, queue)
 
     if use_resampler:
         self.lpfiltcoeffs = gr.firdes.low_pass(1, 5*3.2e6, 1.6e6, 300e3)
         self.resample = blks2.rational_resampler_ccf(interpolation=5, decimation=4, taps=self.lpfiltcoeffs)
-        self.connect(self.u, self.resample, self.demod)
+        self.connect(self.u, self.resample, self.rx_path)
     else:
-        self.connect(self.u, self.demod)
-
-    self.connect(self.demod, self.avg)
-    self.connect(self.demod, (self.preamble, 0))
-    self.connect(self.avg, (self.preamble, 1))
-    self.connect((self.preamble, 0), (self.slicer, 0))
+        self.connect(self.u, self.rx_path)
 
   def tune(self, freq):
     result = self.u.set_center_freq(freq, 0)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -41,6 +41,7 @@ GR_PYTHON_INSTALL(
     parse.py
     msprint.py
     raw_server.py
+    rx_path.py
     sbs1.py
     sql.py
     Quaternion.py

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -51,6 +51,7 @@ from air_modes_swig import *
 
 # import any pure python here
 #
+from rx_path import rx_path
 from parse import parse,modes_reply
 from msprint import output_print
 from sql import output_sql

--- a/python/rx_path.py
+++ b/python/rx_path.py
@@ -1,0 +1,50 @@
+#
+# Copyright 2012 Corgan Labs
+# 
+# This file is part of gr-air-modes
+# 
+# gr-air-modes is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+# 
+# gr-air-modes is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with gr-air-modes; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+# 
+
+from gnuradio import gr
+import air_modes_swig
+
+class rx_path(gr.hier_block2):
+
+    def __init__(self, rate, threshold, queue):
+        gr.hier_block2.__init__(self, "modes_rx_path",
+                                gr.io_signature(1, 1, gr.sizeof_gr_complex),
+                                gr.io_signature(0,0,0))
+
+        self._rate = int(rate)
+        self._threshold = threshold
+        self._queue = queue
+
+        # Convert incoming I/Q baseband to amplitude
+        self._demod = gr.complex_to_mag()
+
+        # Establish baseline amplitude (noise, interference)
+        self._avg = gr.moving_average_ff(100, 1.0/100, 400) # FIXME
+
+        # Synchronize to Mode-S preamble
+        self._sync = air_modes_swig.modes_preamble(self._rate, self._threshold)
+
+        # Slice Mode-S bits and send to message queue
+        self._slicer = air_modes_swig.modes_slicer(self._rate, self._queue)
+
+        self.connect(self, self._demod, (self._sync, 0))
+        self.connect(self._demod, self._avg, (self._sync, 1))
+        self.connect(self._sync, self._slicer)


### PR DESCRIPTION
This commit creates air_modes.rx_path, which is the common portion
of the flowgraph once the sample source and possible resampler are
created.  It takes baseband I/Q and emits Mode-S packets into the
supplied message queue.
