### PR TITLE
Added option for pulse matched filtering

### DIFF
--- a/apps/modes_gui
+++ b/apps/modes_gui
@@ -242,6 +242,7 @@ class mainwindow(QtGui.QMainWindow):
             options["gain"] = float(self.ui.line_gain.text())
             options["threshold"] = float(self.ui.line_threshold.text())
             options["filename"] = str(self.ui.line_inputfile.text())
+            options["pmf"] = self.ui.check_pmf.checkState()
 
             self.fg = adsb_rx_block(options, self.queue) #create top RX block
             self.runner = top_block_runner(self.fg) #spawn new thread to do RX
@@ -423,7 +424,7 @@ class adsb_rx_block (gr.top_block):
         else:
             raise NotImplementedError
 
-        self.rx_path = air_modes.rx_path(rate, options["threshold"], queue)
+        self.rx_path = air_modes.rx_path(rate, options["threshold"], queue, options["pmf"])
 
         if use_resampler:
             self.lpfiltcoeffs = gr.firdes.low_pass(1, 5*3.2e6, 1.6e6, 300e3)

--- a/apps/modes_rx
+++ b/apps/modes_rx
@@ -110,7 +110,7 @@ class adsb_rx_block (gr.top_block):
     if options.output_all :
       pass_all = 1
 
-    self.rx_path = air_modes.rx_path(rate, options.threshold, queue)
+    self.rx_path = air_modes.rx_path(rate, options.threshold, queue, options.pmf)
 
     if use_resampler:
         self.lpfiltcoeffs = gr.firdes.low_pass(1, 5*3.2e6, 1.6e6, 300e3)
@@ -163,6 +163,8 @@ if __name__ == '__main__':
                       help="FlightGear server to send aircraft data, in format host:port")
   parser.add_option("-d","--rtlsdr", action="store_true", default=False,
                       help="Use RTLSDR dongle instead of UHD source")
+  parser.add_option("-p","--pmf", action="store_true", default=False,
+                      help="Use pulse matched filtering")
                       
   (options, args) = parser.parse_args()
 

--- a/res/modes_rx.ui
+++ b/res/modes_rx.ui
@@ -85,7 +85,7 @@
            </sizepolicy>
           </property>
           <property name="currentIndex">
-           <number>3</number>
+           <number>0</number>
           </property>
           <widget class="QWidget" name="setup">
            <property name="sizePolicy">
@@ -103,7 +103,7 @@
               <x>10</x>
               <y>20</y>
               <width>236</width>
-              <height>193</height>
+              <height>251</height>
              </rect>
             </property>
             <property name="title">
@@ -214,7 +214,7 @@
               </rect>
              </property>
              <property name="currentIndex">
-              <number>1</number>
+              <number>0</number>
              </property>
              <widget class="QWidget" name="page_rf">
               <widget class="QComboBox" name="combo_ant">
@@ -302,6 +302,19 @@
                </property>
               </widget>
              </widget>
+            </widget>
+            <widget class="QCheckBox" name="check_pmf">
+             <property name="geometry">
+              <rect>
+               <x>10</x>
+               <y>200</y>
+               <width>221</width>
+               <height>22</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>Use Pulse Matched Filtering</string>
+             </property>
             </widget>
            </widget>
            <widget class="QGroupBox" name="group_output">


### PR DESCRIPTION
Pulse matched filtering places a boxcar filter upstream of the
averager and preamble detector.  The filter length is equivalent
to the number of samples in one Mode S chip (0.5us).  This
technique enhances operation when using sample rates > 4Msps.

When using --pmf, the threshold may need to be reduced a dB or
two from what would have been optimal without --pmf.
- rx_path.py now takes 'use_pmf', defaults to False
- modes_rx has new CLI option '-p' or '--pmf' to turn on PMF
- modes_gui has new checkbox on Setup tab
