### PR TITLE
Remove unneeded parameter from rx_path.get_threshold.

### DIFF
--- a/python/rx_path.py
+++ b/python/rx_path.py
@@ -83,6 +83,6 @@ class rx_path(gr.hier_block2):
     def get_pmf(self, pmf):
         return not (self._bb == self._demod)
 
-    def get_threshold(self, threshold):
+    def get_threshold(self):
         return self._sync.get_threshold()
 


### PR DESCRIPTION
The `threshold` parameter of `rx_path.get_threshold` is unused and looks like it's just an accident from imitating the setter.

This change removes it. It could instead be made optional for compatibility with callers written against the current code.