### PR TITLE
Introduce a Nix derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,25 @@
+let
+  pkgs = import <nixpkgs> {};
+in with pkgs; with pkgs.stdenv; mkDerivation {
+  name = "gr-air-modes";
+  src = ./.;
+  buildInputs = [
+    boost
+    cmake
+    gcc
+    gnumake
+    gnuradio
+    pkgconfig
+    qwt
+    swig
+    (python27.withPackages(ps: [ps.pyqt4 ps.numpy ps.pyzmq]))
+  ];
+  nativeBuildInputs = [ makeWrapper ];
+  configurePhase = ''
+    cmake -DCMAKE_INSTALL_PREFIX=$out
+  '';
+  postFixup = ''
+    wrapProgram $out/bin/modes_gui  --prefix PYTHONPATH : "$out/lib/python2.7/site-packages:$PYTHONPATH"
+    wrapProgram $out/bin/modes_rx   --prefix PYTHONPATH : "$out/lib/python2.7/site-packages:$PYTHONPATH"
+  '';
+}


### PR DESCRIPTION
This permits any user running NixOS to run `nix-build` to install all dependencies and build the local tree.

Tested on NixOS 19.03.